### PR TITLE
Use grayscale background layer to improve maps

### DIFF
--- a/vars_demo.yaml
+++ b/vars_demo.yaml
@@ -56,7 +56,7 @@ vars:
             print_template:
             - A4 portrait
             - A3 portrait
-            default_basemap: map
+            default_basemap: asitvd.fond_gris
             mobile_default_theme:
 #            location:
 #            - "'Lausanne': [535436, 155243, 539476, 150443]"


### PR DESCRIPTION
Use of background layer in grayscale is a best practice in cartography as it
makes overlay layers more readable.