### PR TITLE
Update default_ogc_server value

### DIFF
--- a/vars_demo.yaml
+++ b/vars_demo.yaml
@@ -82,7 +82,7 @@ vars:
     external_themes_url:
 
     mapserverproxy:
-        default_ogc_server: Main PNG
+        default_ogc_server: source for image/png
 
     dbsessions:
         osm:


### PR DESCRIPTION
Who as set the ogc server values (names) in the test database (2.2) ?
It can't work without this PR's change (https://testgmf.sig.cloud.camptocamp.net/2.2)

~~And right now, I don't have any background layer. Should I change anything else ?~~
-> The asitvd background must be served over https. (Why that was changed) ?
