### PR TITLE
Wrong sub-version of GMF 2.3

### DIFF
--- a/.config
+++ b/.config
@@ -1,3 +1,3 @@
 [docker-run]
 image=camptocamp/geomapfish-build
-version=2.3.5.80
+version=2.3.4.80


### PR DESCRIPTION
It seems that GMF demo was upgraded to 2.3.4.80 not 2.3.5.80.