### PR TITLE
Remove args to build script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,8 @@
-ENV_FILES = env.default env.project env.secrets
 BUILD_OPTIONS = --config
 
 .PHONY: build
 build:
-	./build $(BUILD_OPTIONS) $(ENV_FILES)
+	./build $(BUILD_OPTIONS)
 
 
 GPG_KEYS += D1D6A94C # Stéphane Brunner

--- a/README.rst
+++ b/README.rst
@@ -17,7 +17,7 @@ Build
 .. code::
 
   make secrets
-  ./build env.default env.project env.secrets
+  ./build
 
 Run locally
 -----------


### PR DESCRIPTION
With the arguments, `No arguments needed` error is raised