### PR TITLE
Add a search style for mobile_alt

### DIFF
--- a/geoportal/vars.yaml
+++ b/geoportal/vars.yaml
@@ -332,6 +332,15 @@ vars:
           coordinatesProjections: *alternate_projections
           delay: 50
           clearButton: False
+          styles:
+            default:
+              type: Circle
+              radius: 5
+              fill:
+                color: [65, 134, 240, 0.5]
+              stroke:
+                color: [65, 134, 240, 1]
+                width: 2
           actions: []
           datasources:
             - labelKey: label


### PR DESCRIPTION
The search in mobile_alt was not working because it had no style.
Found in connection with https://jira.camptocamp.com/browse/GSGMF-1561.