### PR TITLE
Various fixes 2.7

### DIFF
--- a/env.project
+++ b/env.project
@@ -1,7 +1,7 @@
 # Custom project values
 COMPOSE_PROJECT_NAME=demo
 DOCKER_BASE=camptocamp/geomapfishdemo
-DOCKER_TAG=2.6
+DOCKER_TAG=2.7
 
 PGHOST=pg-gs.camptocamp.com
 PGHOST_SLAVE=pg-gs.camptocamp.com
@@ -9,8 +9,8 @@ PGPORT=30100
 PGPORT_SLAVE=30101
 # Should be set to 'prefer' to be able to connect to a local database
 PGSSLMODE=require
-PGSCHEMA=main_2_6
-PGSCHEMA_STATIC=static_2_6
+PGSCHEMA=main_2_7
+PGSCHEMA_STATIC=static_2_7
 
 # For Exoscale S3
 AWS_DEFAULT_REGION=ch-dk-2

--- a/geoportal/vars.yaml
+++ b/geoportal/vars.yaml
@@ -4,7 +4,6 @@ extends: CONST_vars.yaml
 vars:
   srid: 2056
   osm_db: '{OSM_PGDATABASE}'
-  schema: 'main_2_7'
 
   tiles_s3_bucket: '{TILEGENERATION_S3_BUCKET}'
   raster_base_path: '{RASTER_BASE_PATH}'


### PR DESCRIPTION
Still a problem with alembic locally : 
https://github.com/camptocamp/demo_geomapfish/blob/prod-2-7/docker-compose.yaml#L113

camptocamp/geomapfish-geoportal:2.7 does not exists.

Should it be `camptocamp/geomapfishapp-geoportal:${DOCKER_TAG}`  in simple mode
And `camptocamp/geomapfishdemo-geoportal:${DOCKER_TAG} ` in advanced mode