### PR TITLE
mbstyle: Add missing default style, target more entities

### DIFF
--- a/geoportal/geomapfish_geoportal/static/mb_styles/osm_landuse.json
+++ b/geoportal/geomapfish_geoportal/static/mb_styles/osm_landuse.json
@@ -17,7 +17,14 @@
       "source-layer": "osm_landuse",
       "type": "fill",
       "paint": {
-        "fill-color": ["match", ["get", "type"], ["forest", "wood"], "#9ce69c"]
+        "fill-color": [
+          "match",
+          ["get", "type"],
+          "forest", "#9ce69c",
+          "farmland", "#e3b732",
+          "residential", "#de9f8e",
+          "#bed2d4"
+        ]
       }
     }
   ]


### PR DESCRIPTION
Add require default style.
Add farmland and residential (both ~8000 entities) in style because forest has only 35 entities... (wood 0).