### PR TITLE
Update mapillary access token

### DIFF
--- a/geoportal/vars.yaml
+++ b/geoportal/vars.yaml
@@ -153,7 +153,7 @@ vars:
         gmfQueryGrid: True
         ngeoStreetviewOptions:
           viewer: mapillary
-          key: d1dNaFk4aDVoVVlZd0dEZG95Wm84QTpkYmRkOGQyMWRkMThiM2E2
+          key: MLY|4430042800443980|51905165b239b0272b30a8e9b70a5e76
         ngeoGoogleStreetviewOptions:
           viewer: google
         ngeoWfsPermalinkOptions:


### PR DESCRIPTION
For GEO-4868

Mapillary-js v2 doesn't work anymore. I'm switching to mapillary-js v4 here: https://github.com/camptocamp/ngeo/pull/7596
We need here to update the token.

I'll backport that to every other branches >= 2.6. (mabye less) => done
I'll update gopass => done