### PR TITLE
Improve mapbox style example

### DIFF
--- a/geoportal/geomapfish_geoportal/static/mb_styles/osm_landuse.json
+++ b/geoportal/geomapfish_geoportal/static/mb_styles/osm_landuse.json
@@ -12,7 +12,7 @@
   },
   "layers": [
     {
-      "id": "osm_landuse",
+      "id": "osm_landuse_fill",
       "source": "osm_landuse",
       "source-layer": "osm_landuse",
       "type": "fill",
@@ -20,15 +20,49 @@
         "fill-color": [
           "match",
           ["get", "type"],
-          "forest",
-          "#9ce69c",
-          "farmland",
-          "#e3b732",
-          "residential",
-          "#de9f8e",
-          "#bed2d4"
+          "plant_nursery", "#55ff11",
+          "retail", "#ff5511",
+          "military", "#667c4d",
+          "railway", "#ff0000",
+          "recreation_groun", "#bfbfbf",
+          "village_green", "#009933",
+          "greenhouse_horti", "#99cc00",
+          "reservoir", "#3399ff",
+          "commercial", "#ffcc66",
+          "quarry", "#ffcccc",
+          "construction", "#ff99ff",
+          "farm", "#cc9900",
+          "orchard", "#99cc00",
+          "basin", "#3333cc",
+          "cemetery", "#666666",
+          "allotments", "#ccffcc",
+          "industrial", "#cccc00",
+          "vineyard", "#cc6699",
+          "farmyard", "#996633",
+          "meadow", "#ccff66",
+          "grass", "#33cc33",
+          "forest", "#006600",
+          "farmland", "#e3b732",
+          "residential", "#de9f8e",
+          "#e6e6e6"
         ]
       }
+    },
+    {
+      "id": "osm_landuse_text",
+      "source": "osm_landuse",
+      "source-layer": "osm_landuse",
+      "type": "symbol",
+      "paint": {
+         "text-color": "#000066"
+      },
+      "layout": {
+         "text-line-height": 1.2,
+         "text-field": "{type}\n{name}\n",
+         "text-font": ["sans-serif"],
+         "text-size": 12,
+         "text-justify": "center"
+       }
     }
   ]
 }


### PR DESCRIPTION
More type-filled polygon, and add text.

Style are hard to create manually, we should probably have a mapbox account to use https://www.mapbox.com/mapbox-studio.

I'm pretty sure there are some limitation to convert a mapbox style to an ol style using ol-mapboy-style. We should keep that in mind.