### PR TITLE
Do not consume sentry errors for development

### DIFF
--- a/env.project
+++ b/env.project
@@ -58,5 +58,5 @@ RASTER_BASE_PATH=/vsis3/data-gmf-demo
 
 QGIS_VERSION=master
 
-SENTRY_URL=https://8dfa6c72fcad48c487c6a89b22ce581b@o330647.ingest.sentry.io/1851011
-SENTRY_CLIENT_ENVIRONMENT=dev
+# SENTRY_URL=https://8dfa6c72fcad48c487c6a89b22ce581b@o330647.ingest.sentry.io/1851011
+# SENTRY_CLIENT_ENVIRONMENT=dev


### PR DESCRIPTION
For me we should do the same in prod-2-7 (with docker-compose).
It send errors to sentry each time I test something in demo locally.
We should only activate it on preprod and prod instances.