### PR TITLE
Remove print_get_redirect for compatibility with local print

### DIFF
--- a/geoportal/vars.yaml
+++ b/geoportal/vars.yaml
@@ -434,7 +434,6 @@ vars:
             partitionlimit: 5
     oeedit:
       extends: desktop
-  print_get_redirect: True
 
   urllogin:
     aes_key: foobarfoobar1234


### PR DESCRIPTION
When using local print we cannot redirect browser to http://print:8080/print

I do not understand how it was working before as print_get_redirect was set to True 3 years ago.

On prod-2-7 it already has been removed.