### PR TITLE
Add missing configuration in pyproject.toml

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,5 +54,6 @@ acceptance:
 
 acceptance-dev:
 	docker compose --file=docker-compose.yaml --file=docker-compose-db.yaml --file=docker-compose.override.sample.yaml up -d
+	sleep 2
 	docker compose exec -T tools pytest tests/
 	ci/docker-compose-check

--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ acceptance-init:
 	docker compose exec -T tools psql --command='CREATE EXTENSION IF NOT EXISTS postgis'
 	docker compose exec -T tools psql --command='CREATE EXTENSION IF NOT EXISTS pg_trgm'
 	docker compose exec -T tools psql --command='CREATE EXTENSION IF NOT EXISTS hstore'
-	scripts/db-restore --docker compose-file=docker-compose.yaml --docker compose-file=docker-compose-db.yaml \
+	scripts/db-restore --docker-compose-file=docker-compose.yaml --docker-compose-file=docker-compose-db.yaml \
 		--arg=--clean --arg=--if-exists --arg=--verbose data/prod-2-7.dump
 	docker compose restart geoportal alembic
 	docker compose exec -T geoportal wait-db
@@ -50,9 +50,9 @@ acceptance-init:
 .PHONY: acceptance
 acceptance:
 	docker compose exec -T tools pytest tests/
-	ci/docker compose-check
+	ci/docker-compose-check
 
 acceptance-dev:
 	docker compose --file=docker-compose.yaml --file=docker-compose-db.yaml --file=docker-compose.override.sample.yaml up -d
 	docker compose exec -T tools pytest tests/
-	ci/docker compose-check
+	ci/docker-compose-check

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,9 @@
 [tool.black]
 line-length = 110
 target-version = ['py38']
+
+[tool.poetry]
+name = "demo_geomapfish"
+version = "0.0.0"
+description = "Demo of GeoMapFish Application"
+authors = ["Camptocamp <info@camptocamp.com>"]


### PR DESCRIPTION
Needed to make `poetry --version` work, used in the audit.