### PR TITLE
Add missing configuration in pyproject.toml

### DIFF
--- a/custom/custom/alembic/env.py
+++ b/custom/custom/alembic/env.py
@@ -1,4 +1,5 @@
 """Pyramid bootstrap environment. """
+
 from alembic import context
 from custom.models.meta import Base
 from pyramid.paster import get_appsettings, setup_logging

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,3 +5,9 @@ target-version = ['py38']
 [tool.isort]
 profile = "black"
 line_length = 110
+
+[tool.poetry]
+name = "demo_geomapfish"
+version = "0.0.0"
+description = "Demo of GeoMapFish Application"
+authors = ["Camptocamp <info@camptocamp.com>"]


### PR DESCRIPTION
Needed to make `poetry --version` work, used in the audit.