### PR TITLE
Remove print secret requirements

### DIFF
--- a/print/print-apps/geomapfish/config.yaml.tmpl
+++ b/print/print-apps/geomapfish/config.yaml.tmpl
@@ -4,23 +4,6 @@ throwErrorOnExtraParameters: true
 defaultToSvg: true
 resourceBundle: localisation
 
-smtp:
-  username: ${SMTP_USER}
-  password: ${SMTP_PASSWORD}
-  fromAddress: info@camptocamp.com
-  host: email-smtp.eu-west-1.amazonaws.com
-  port: 465
-  ssl: True
-  subject: Map from GeoMapFish demo
-  body: Your printed map form GeoMapFish demo is <a href="{url}">here</a>.
-  storage: !s3reportStorage
-    bucket: print-mutualized
-    prefix: gmf_demo
-    endpointUrl: https://sos-ch-dk-2.exo.io/
-    region: ch-dk-2
-    accessKey: ${AWS_ACCESS_KEY_ID}
-    secretKey: ${AWS_SECRET_ACCESS_KEY}
-
 allowedReferers: &allowedHosts
   ${DISABLE_MUTUALIZED_PRINT}- !hostnameMatch
   ${DISABLE_MUTUALIZED_PRINT}  host: ${MUTUALIZED_PRINT_URL}

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,3 +1,4 @@
+import time
 from typing import Dict
 
 import pytest
@@ -32,7 +33,16 @@ import requests
 )
 def test_url(url: str, params: Dict[str, str], timeout: int) -> None:
     """Tests that some URL didn't return an error."""
-    response = requests.get(url, params=params, verify=False, timeout=timeout)  # nosec
+    code = 503
+    count = 0
+    while code == 503 and count < 5:
+        response = requests.get(url, params=params, verify=False, timeout=timeout)
+        code = response.status_code
+        count += 1
+        if code == 503:
+            print(f"Retry {count} for {url}")
+            time.sleep(1)
+
     assert response.status_code == 200, response.text
 
 


### PR DESCRIPTION
The goal, is do not have to migrate to the new shared config manager to be able to have secrets.

This functionality is kept on 2.9.