### PR TITLE
Fix-missing-jquery-datetimepicker

### DIFF
--- a/ui/desktop.html
+++ b/ui/desktop.html
@@ -520,6 +520,12 @@
     ></script>
     <script
       crossorigin="anonymous"
+      integrity="sha384-acxrOGOegWGJXP6/VkkaGjRqF4TMBWEVYFKixA2KG2kgTCIeyYyiHaGE8rGjzRQm"
+      referrerpolicy="no-referrer"
+      src="https://cdn.jsdelivr.net/npm/jquery-datetimepicker@2.5.21/build/jquery.datetimepicker.full.min.js"
+    ></script>
+    <script
+      crossorigin="anonymous"
       integrity="sha384-SStJQoPipVtHHnIgUfDI+jTAbSyU+HMbhwt2XRRNpLIRFg9VguopT6Y4+cdOlkqg"
       referrerpolicy="no-referrer"
       src="https://cdn.jsdelivr.net/npm/jquery-ui@1.14.1/dist/jquery-ui.min.js"

--- a/ui/iframe_api.html
+++ b/ui/iframe_api.html
@@ -173,6 +173,12 @@
     ></script>
     <script
       crossorigin="anonymous"
+      integrity="sha384-acxrOGOegWGJXP6/VkkaGjRqF4TMBWEVYFKixA2KG2kgTCIeyYyiHaGE8rGjzRQm"
+      referrerpolicy="no-referrer"
+      src="https://cdn.jsdelivr.net/npm/jquery-datetimepicker@2.5.21/build/jquery.datetimepicker.full.min.js"
+    ></script>
+    <script
+      crossorigin="anonymous"
       integrity="sha384-SStJQoPipVtHHnIgUfDI+jTAbSyU+HMbhwt2XRRNpLIRFg9VguopT6Y4+cdOlkqg"
       referrerpolicy="no-referrer"
       src="https://cdn.jsdelivr.net/npm/jquery-ui@1.14.1/dist/jquery-ui.min.js"

--- a/ui/mobile.html
+++ b/ui/mobile.html
@@ -347,6 +347,12 @@
     ></script>
     <script
       crossorigin="anonymous"
+      integrity="sha384-acxrOGOegWGJXP6/VkkaGjRqF4TMBWEVYFKixA2KG2kgTCIeyYyiHaGE8rGjzRQm"
+      referrerpolicy="no-referrer"
+      src="https://cdn.jsdelivr.net/npm/jquery-datetimepicker@2.5.21/build/jquery.datetimepicker.full.min.js"
+    ></script>
+    <script
+      crossorigin="anonymous"
       integrity="sha384-SStJQoPipVtHHnIgUfDI+jTAbSyU+HMbhwt2XRRNpLIRFg9VguopT6Y4+cdOlkqg"
       referrerpolicy="no-referrer"
       src="https://cdn.jsdelivr.net/npm/jquery-ui@1.14.1/dist/jquery-ui.min.js"

--- a/ui/vite.config.js
+++ b/ui/vite.config.js
@@ -50,6 +50,7 @@ export default defineConfig({
       'api': path.resolve(__dirname, 'node_modules/ngeo/distlib/api'),
       'jquery-ui/datepicker': path.resolve(__dirname, 'empty.js'), // For angular-ui-date
       // Save about of 45k os bandwidth (gzipped) by unworking ignoring import done by a script downloaded from a CDN.
+      'jquery-datetimepicker/jquery.datetimepicker': path.resolve(__dirname, 'empty.js'),
       'bootstrap/js/src/popover': path.resolve(__dirname, 'empty.js'),
       'bootstrap/js/src/tooltip': path.resolve(__dirname, 'empty.js'),
       'bootstrap/js/src/alert': path.resolve(__dirname, 'empty.js'),


### PR DESCRIPTION
This fix GSGMF-2118 , the editing.

At the end, this problem was note caused by the "ngeo-datepicker. But the ngeo datepicker make problems in the layertree and the filter and will be corrected by GSGMF-2138
<!-- pull request links -->
See JIRA issue: [GSGMF-2118](https://camptocamp.atlassian.net/browse/GSGMF-2118).

[GSGMF-2118]: https://camptocamp.atlassian.net/browse/GSGMF-2118?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ