### PR TITLE
Add demo.geomapfish.dev as allowed referer (geogirafe)

### DIFF
--- a/geoportal/vars.yaml
+++ b/geoportal/vars.yaml
@@ -749,7 +749,7 @@ vars:
     - https://2-8.geomapfish-demo.prod.apps.gs-ch-prod.camptocamp.com
     - https://2-8.geomapfish-demo.prod.apps.blue.gs-ch-prod.camptocamp.com
     - https://2-8.geomapfish-demo.prod.apps.green.gs-ch-prod.camptocamp.com
-    - demo.geomapfish.dev
+    - https://demo.geomapfish.dev
     - https://camptocamp.github.io
     - https://fredj.github.io
     - https://ger-benjamin.github.io

--- a/geoportal/vars.yaml
+++ b/geoportal/vars.yaml
@@ -694,6 +694,7 @@ vars:
       - arnaud-morvan.github.io
       - julsbreakdown.github.io
       - adube.github.io
+      - demo.geomapfish.dev
       - localhost
       - 127.0.0.1
 
@@ -748,6 +749,7 @@ vars:
     - https://2-8.geomapfish-demo.prod.apps.gs-ch-prod.camptocamp.com
     - https://2-8.geomapfish-demo.prod.apps.blue.gs-ch-prod.camptocamp.com
     - https://2-8.geomapfish-demo.prod.apps.green.gs-ch-prod.camptocamp.com
+      demo.geomapfish.dev
     - https://camptocamp.github.io
     - https://fredj.github.io
     - https://ger-benjamin.github.io

--- a/geoportal/vars.yaml
+++ b/geoportal/vars.yaml
@@ -749,7 +749,7 @@ vars:
     - https://2-8.geomapfish-demo.prod.apps.gs-ch-prod.camptocamp.com
     - https://2-8.geomapfish-demo.prod.apps.blue.gs-ch-prod.camptocamp.com
     - https://2-8.geomapfish-demo.prod.apps.green.gs-ch-prod.camptocamp.com
-      demo.geomapfish.dev
+    - demo.geomapfish.dev
     - https://camptocamp.github.io
     - https://fredj.github.io
     - https://ger-benjamin.github.io


### PR DESCRIPTION
the referer is needed to fix the legacy auth in geogirafe demo.

what is the policy in porting to prod-2-8-advance ?